### PR TITLE
Add Gecko Profiling support for Firefox

### DIFF
--- a/lib/core/engine/command/javaScript.js
+++ b/lib/core/engine/command/javaScript.js
@@ -42,7 +42,7 @@ class JavaScript {
   }
 
   /**
-   * Run privileged JavaScript.
+   * Run synchronous privileged JavaScript.
    * @param {string} js
    * @returns {Promise} Promise object represents when the JavaScript has been executed by the browser
    * @throws Will throw an error if the JavsScript can't run
@@ -53,6 +53,23 @@ class JavaScript {
       return value;
     } catch (e) {
       log.error('Could not run privileged JavaScript %s ', js);
+      log.verbose(e);
+      throw e;
+    }
+  }
+
+  /**
+   * Run asynchronous privileged JavaScript.
+   * @param {string} js
+   * @returns {Promise} Promise object represents when the JavaScript has been executed by the browser
+   * @throws Will throw an error if the JavsScript can't run
+   */
+  async runPrivilegedAsync(js) {
+    try {
+      const value = await this.browser.runPrivilegedAsyncScript(js, 'CUSTOM ASYNC PRIVILEGED');
+      return value;
+    } catch (e) {
+      log.error('Could not run async privileged JavaScript %s ', js);
       log.verbose(e);
       throw e;
     }

--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -309,7 +309,7 @@ class SeleniumRunner {
       const oldContext = this.driver.getContext();
 
       try {
-        await this.driver.setContext("chrome");
+        await this.driver.setContext('chrome');
 
         return timeout(
           this.driver.executeScript(script, args),
@@ -320,7 +320,7 @@ class SeleniumRunner {
         await this.driver.setContext(oldContext);
       }
     } catch (e) {
-      log.error("Couldn't execute privileged script named " + name + ' error:' + e);
+      log.error('Couldn\'t execute privileged script named ' + name + ' error:' + e);
       throw e;
     }
   }
@@ -343,6 +343,45 @@ class SeleniumRunner {
     } catch (e) {
       log.error("Couldn't execute async script named " + name + ' error:' + e);
       throw e;
+    }
+  }
+
+  /**
+   * Run asynchronous privileged JavaScript with args.
+   * @param {string} script - the actual script
+   * @param {string} name - the name of the script (for logging)
+   * @param {*} args - arguments to the script
+   * @throws {BrowserError}
+   */
+  async runPrivilegedAsyncScript(script, name, args) {
+    if (this.options.browser !== 'firefox') {
+      throw new BrowserError(`Only Firefox browsers can run privileged JavaScript: ${this.options.browser}`);
+    }
+
+    if (log.isEnabledFor(log.TRACE)) {
+      log.verbose('Executing privileged async script %s', script);
+    } else if (log.isEnabledFor(log.VERBOSE)) {
+      log.verbose('Executing privileged async script %s', name);
+    }
+
+    try {
+      const oldContext = this.driver.getContext();
+
+      try {
+        await this.driver.setContext('chrome');
+
+        try {
+          return this.driver.executeAsyncScript(script, args);
+        } catch (e) {
+          log.error('Couldn\'t execute async script named ' + name + ' error:' + e);
+          throw e;
+        }
+      } finally {
+        await this.driver.setContext(oldContext);
+      }
+    } catch (ce) {
+      log.error('Couldn\'t execute async script named ' + name + ' error:' + ce);
+      throw ce;
     }
   }
 

--- a/lib/firefox/geckoProfilerDefaults.js
+++ b/lib/firefox/geckoProfilerDefaults.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  features: 'js,stackwalk,leaf,responsiveness',
+  threads: 'GeckoMain,Compositor,Renderer',
+  interval: 1,
+  bufferSize: 1000000
+};

--- a/lib/firefox/webdriver/firefoxDelegate.js
+++ b/lib/firefox/webdriver/firefoxDelegate.js
@@ -26,7 +26,22 @@ class FirefoxDelegate {
     this.hars = [];
   }
 
-  async onStartIteration() {}
+  async onStartIteration(runner) {
+    if (this.firefoxConfig.geckoProfiler) {
+      let chosenFeatures = this.firefoxConfig.geckoProfilerParams.features.split(',');
+      let featureString = '["' + chosenFeatures.join('","') + '"]';
+
+      let chosenThreads = this.firefoxConfig.geckoProfilerParams.threads.split(',');
+      let threadString = '["' + chosenThreads.join('","') + '"]';
+
+      let interval = this.firefoxConfig.geckoProfilerParams.interval;
+      let bufferSize = this.firefoxConfig.geckoProfilerParams.bufferSize;
+
+      const script = `Services.profiler.StartProfiler(${bufferSize},${interval},${featureString},
+        ${chosenFeatures.length},${threadString},${chosenThreads.length});`;
+      await runner.runPrivilegedScript(script, 'Start GeckoProfiler');
+    }
+  }
 
   async onStopIteration() {}
 
@@ -43,6 +58,27 @@ class FirefoxDelegate {
         )
       );
       // TODO clear the original log file!
+    }
+
+    if (this.firefoxConfig.geckoProfiler) {
+      let profileFilename = path.join(
+        this.baseDir,
+        pathToFolder(result.url, this.options),
+        `geckoProfile-${index}.json`
+      );
+
+      // Must use String.raw or else the backslashes on Windows will be escapes.
+      const script = `
+      var callback = arguments[arguments.length - 1];
+       Services.profiler.dumpProfileToFileAsync(String.raw\`${profileFilename}\`)
+        .then(callback)
+        .catch((e) => callback({'error' : e}));
+       `;
+      await runner.runPrivilegedAsyncScript(script, 'Collect GeckoProfiler');
+      await runner.runPrivilegedScript(
+        'Services.profiler.StopProfiler();',
+        'Stop GeckoProfiler'
+      );
     }
 
     if (this.skipHar) {

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -9,6 +9,7 @@ const util = require('util');
 const hasbin = require('hasbin');
 const videoDefaults = require('../video/defaults');
 const screenshotDefaults = require('../screenshot/defaults');
+const geckoProfilerDefaults = require('../firefox/geckoProfilerDefaults');
 
 function validateInput(argv) {
   // validate URLs/files
@@ -238,6 +239,36 @@ module.exports.parseCommandLine = function parseCommandLine() {
         'variable frame rate video for analysis.',
       default: true,
       type: 'boolean',
+      group: 'firefox'
+    })
+    .option('firefox.geckoProfiler', {
+      describe: 'Collect a profile using the internal gecko profiler',
+      default: false,
+      type: 'boolean',
+      group: 'firefox'
+    })
+    .option('firefox.geckoProfilerParams.features', {
+      describe: 'Enabled features during gecko profiling',
+      default: geckoProfilerDefaults.features,
+      type: 'string',
+      group: 'firefox'
+    })
+    .option('firefox.geckoProfilerParams.threads', {
+      describe: 'Threads to profile.',
+      default: geckoProfilerDefaults.threads,
+      type: 'string',
+      group: 'firefox'
+    })
+    .option('firefox.geckoProfilerParams.interval', {
+      describe: 'Sampling interval in ms.',
+      default: geckoProfilerDefaults.interval,
+      type: 'number',
+      group: 'firefox'
+    })
+    .option('firefox.geckoProfilerParams.bufferSize', {
+      describe: 'Buffer size in elements. Default is ~90MB.',
+      default: geckoProfilerDefaults.bufferSize,
+      type: 'number',
       group: 'firefox'
     })
     .option('firefox.collectMozLog', {


### PR DESCRIPTION
This adds support for three new CLI options:

--firefox.geckoProfiler [true/false]
        - Enabled the gecko profiler when Firefox is used
--firefox.geckoProfilerFeatures 
        - Define a set of features to enable.   The default set is "js,stackwalk,leaf,responsiveness" but other features such as jstracer can be included with this option.  
--firefox.geckoProfilerThreads
        - Define which threads to sample on.  The default set is GeckoMain,Compositor,Renderer

This PR also adds support for privileged async JS execution thanks to the help of @ncalexan .