### PR TITLE
Add contentfulness speedindex calculations

### DIFF
--- a/lib/core/engine/collector.js
+++ b/lib/core/engine/collector.js
@@ -176,6 +176,8 @@ class Collector {
               data.visualMetrics.SpeedIndex
             } PerceptualSpeedIndex: ${
               data.visualMetrics.PerceptualSpeedIndex
+            } ContentfulSpeedIndex: ${
+              data.visualMetrics.ContentfulSpeedIndex
             } VisualComplete85: ${
               data.visualMetrics.VisualComplete85
             } LastVisualChange: ${data.visualMetrics.LastVisualChange}`

--- a/lib/core/engine/collector.js
+++ b/lib/core/engine/collector.js
@@ -174,6 +174,8 @@ class Collector {
               data.visualMetrics.FirstVisualChange
             } SpeedIndex: ${
               data.visualMetrics.SpeedIndex
+            } PerceptualSpeedIndex: ${
+              data.visualMetrics.PerceptualSpeedIndex
             } VisualComplete85: ${
               data.visualMetrics.VisualComplete85
             } LastVisualChange: ${data.visualMetrics.LastVisualChange}`

--- a/lib/support/har/index.js
+++ b/lib/support/har/index.js
@@ -173,6 +173,7 @@ module.exports = {
         'VisualReadiness',
         'SpeedIndex',
         'PerceptualSpeedIndex',
+        'ContentfulSpeedIndex',
         'VisualProgress'
       ];
 

--- a/lib/support/util.js
+++ b/lib/support/util.js
@@ -32,6 +32,8 @@ module.exports = {
         pageLoad = '',
         rumSpeedIndex = '',
         speedIndex = '',
+        perceptualSpeedIndex = '',
+        contentfulSpeedIndex = '',
         startRender = '',
         visualComplete85 = '',
         backEndTime = '',
@@ -75,6 +77,16 @@ module.exports = {
           vm ? vm.SpeedIndex : vm,
           m
         );
+        perceptualSpeedIndex = this.formatMetric(
+          'perceptualSpeedIndex',
+          vm ? vm.PerceptualSpeedIndex : vm,
+          m
+        );
+        contentfulSpeedIndex = this.formatMetric(
+          'contentfulSpeedIndex',
+          vm ? vm.ContentfulSpeedIndex : vm,
+          m
+        );
         startRender = this.formatMetric(
           'firstVisualChange',
           vm ? vm.FirstVisualChange : vm,
@@ -107,6 +119,8 @@ module.exports = {
           domContent,
           pageLoad,
           speedIndex,
+          perceptualSpeedIndex,
+          contentfulSpeedIndex,
           visualComplete85,
           lastVisualChange,
           rumSpeedIndex

--- a/lib/video/postprocessing/visualmetrics/single/visualMetrics.js
+++ b/lib/video/postprocessing/visualmetrics/single/visualMetrics.js
@@ -34,6 +34,7 @@ module.exports = {
       videoPath,
       '--orange',
       '--perceptual',
+      '--contentful',
       '--force',
       '--renderignore',
       5,


### PR DESCRIPTION
Add a new visual metric based on edge detection.  This adds a new option in visualmetrics.py, --contentful, that calculates a speed index using edge detection histograms.  This new metric, designed by Bas Schouten, is an attempt to measure real content on a page load, and heavily favours text.  One big advantage is that it does not suffer from splash screens like the one experienced from tripadvisor.com.  

Additionally, this will remove lastVisualChange and rum speed index from the stdout printing on each iteration, but it will still remain in the browsertime.json output.  