### PR TITLE
Update parameters for gecko profiler start script

### DIFF
--- a/lib/firefox/webdriver/firefoxDelegate.js
+++ b/lib/firefox/webdriver/firefoxDelegate.js
@@ -37,8 +37,24 @@ class FirefoxDelegate {
       let interval = this.firefoxConfig.geckoProfilerParams.interval;
       let bufferSize = this.firefoxConfig.geckoProfilerParams.bufferSize;
 
-      const script = `Services.profiler.StartProfiler(${bufferSize},${interval},${featureString},
-        ${chosenFeatures.length},${threadString},${chosenThreads.length});`;
+      const script = `
+        if(Services.profiler.StartProfiler.length == 5) {
+          Services.profiler.StartProfile(
+            ${bufferSize},
+            ${interval},
+            ${featureString},
+            ${threadString}
+          );
+        } else if (Services.profiler.StartProfiler.length == 7) {
+          Services.profiler.StartProfile(
+            ${bufferSize},
+            ${interval},
+            ${featureString},
+            ${chosenFeatures.length},
+            ${threadString},
+            ${chosenThreads.length}
+          );
+        };`;
       await runner.runPrivilegedScript(script, 'Start GeckoProfiler');
     }
   }


### PR DESCRIPTION
The parameters for nsIProfiler StartProfiler method has changed and no
longer accepts features and threads array lengths because the XPIDL
interface was updated to use Array<T> in
https://bugzilla.mozilla.org/show_bug.cgi?id=1551106.