### PR TITLE
Use the new StartProfiler API for Firefox 69 and above

### DIFF
--- a/lib/firefox/webdriver/firefoxDelegate.js
+++ b/lib/firefox/webdriver/firefoxDelegate.js
@@ -37,8 +37,22 @@ class FirefoxDelegate {
       let interval = this.firefoxConfig.geckoProfilerParams.interval;
       let bufferSize = this.firefoxConfig.geckoProfilerParams.bufferSize;
 
-      const script = `Services.profiler.StartProfiler(${bufferSize},${interval},${featureString},
+      // Firefox 69 and above has a slightly different API for StartProfiler
+      const parameterLength = await runner.runPrivilegedScript(
+        'return Services.profiler.StartProfiler.length;',
+        'Get StartProfiler.length'
+      );
+
+      let script;
+      if (parameterLength === 7) {
+        script = `Services.profiler.StartProfiler(${bufferSize},${interval},${featureString},
         ${chosenFeatures.length},${threadString},${chosenThreads.length});`;
+      } else if (parameterLength === 5) {
+        script = `Services.profiler.StartProfiler(${bufferSize},${interval},${featureString},${threadString});`;
+      } else {
+        log.error('Unknown Gecko Profiler API');
+      }
+
       await runner.runPrivilegedScript(script, 'Start GeckoProfiler');
     }
   }


### PR DESCRIPTION
The StartProfiler call was changed in https://bugzilla.mozilla.org/show_bug.cgi?id=1551106 so that it no longer requires a length parameter for each array.  We'll need to check FF version to decide which format to use.