### PR TITLE
Stop the Web Driver default service, if one has been configured.

### DIFF
--- a/lib/chrome/webdriver/index.js
+++ b/lib/chrome/webdriver/index.js
@@ -19,9 +19,9 @@ const timelineTraceCategories =
 /**
  * Configure a WebDriver builder based on the specified options.
  * @param builder
- * @param {Object} options the options for a web driver.
+ * @param {!Promise<Object>} options the options for a web driver.
  */
-module.exports.configureBuilder = function(builder, baseDir, options) {
+module.exports.configureBuilder = async function(builder, baseDir, options) {
   const chromeConfig = options.chrome || {};
   const moduleRootPath = path.resolve(__dirname, '..', '..', '..');
 

--- a/lib/core/webdriver/index.js
+++ b/lib/core/webdriver/index.js
@@ -30,11 +30,11 @@ module.exports.createWebDriver = async function(baseDir, options) {
 
   switch (browser) {
     case 'chrome':
-      chrome.configureBuilder(builder, baseDir, options);
+      await chrome.configureBuilder(builder, baseDir, options);
       break;
 
     case 'firefox':
-      firefox.configureBuilder(builder, baseDir, options);
+      await firefox.configureBuilder(builder, baseDir, options);
       break;
 
     default:

--- a/lib/firefox/webdriver/index.js
+++ b/lib/firefox/webdriver/index.js
@@ -11,7 +11,9 @@ const get = require('lodash.get');
 const geckodriver = require('@sitespeed.io/geckodriver');
 const defaultFirefoxPreferences = require('./firefoxPreferences');
 
-module.exports.configureBuilder = function(builder, baseDir, options) {
+let serviceBuilder;
+
+module.exports.configureBuilder = async function(builder, baseDir, options) {
   const firefoxConfig = options.firefox || {};
   const moduleRootPath = path.resolve(__dirname, '..', '..', '..');
 
@@ -27,8 +29,13 @@ module.exports.configureBuilder = function(builder, baseDir, options) {
   // port is not held.  That means the OS can allocate it, and indeed
   // collisions are frequent in the wild.  By configuring the Web
   // Driver service, we fix a new port for `geckodriver` each
-  // iteration, avoiding port collisions.
-  let serviceBuilder = new firefox.ServiceBuilder(geckodriverPath);
+  // iteration, avoiding port collisions.  However, we must also stop
+  // any existing Web Driver service each iteration as well.
+  if (serviceBuilder) {
+    await serviceBuilder.stop();
+  }
+
+  serviceBuilder = new firefox.ServiceBuilder(geckodriverPath);
   if (options.verbose >= 2) {
     // This echoes the output from geckodriver to the console.
     serviceBuilder.setStdio('inherit');


### PR DESCRIPTION
This is yet more work-around for Android-specific issues with port
allocations in `geckodriver`.