### PR TITLE
Do not navigate to 'data:text/html;charset=utf-8' only on FF for Android

### DIFF
--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -134,7 +134,10 @@ class Iteration {
         at ChromeDelegate.onCollect (/Users/peter/git/browsertime/lib/chrome/webdriver/chromeDelegate.js:135:31)
         at process._tickCallback (internal/process/next_tick.js:68:7)
         */
-        if (options.browser === 'chrome' && !options.processStartTime) {
+        if (
+          !options.processStartTime &&
+          !(isAndroidConfigured(options) && options.browser == 'firefox')
+        ) {
           await browser.getDriver().get('data:text/html;charset=utf-8,');
         }
       }


### PR DESCRIPTION
Navigating to 'data:text/html;charset=utf-8' is required on Desktop to generate an orange frame for video recording.  