### PR TITLE
Embed visual metrics into gecko profile

### DIFF
--- a/lib/core/engine/iteration.js
+++ b/lib/core/engine/iteration.js
@@ -4,6 +4,7 @@ const webdriver = require('selenium-webdriver');
 const log = require('intel').getLogger('browsertime');
 const SeleniumRunner = require('../seleniumRunner');
 const preURL = require('../../support/preURL');
+const pathToFolder = require('../../support/pathToFolder');
 const setResourceTimingBufferSize = require('../../support/setResourceTimingBufferSize');
 const engineUtils = require('../../support/engineUtils');
 const Video = require('../../video/video');
@@ -18,6 +19,8 @@ const Set = require('./command/set.js');
 const Cache = require('./command/cache.js');
 const Meta = require('./command/meta.js');
 const ChromeDevToolsProtocol = require('./command/chromeDevToolsProtocol.js');
+const path = require('path');
+const fs = require('fs');
 
 const { isAndroidConfigured } = require('../../android');
 
@@ -195,6 +198,35 @@ class Iteration {
               result[i].browserScripts.pageinfo.visualElements
             );
             result[i].visualMetrics = videoMetrics.visualMetrics;
+
+            if (
+              options.browser === 'firefox' &&
+              options.firefox &&
+              options.firefox.geckoProfiler
+            ) {
+              const profileFilename = path.join(
+                this.engineDelegate.baseDir,
+                pathToFolder(result[i].url, options),
+                `geckoProfile-${index}.json`
+              );
+
+              try {
+                const geckoProfile = JSON.parse(
+                  fs.readFileSync(profileFilename)
+                );
+                if (!geckoProfile.meta) {
+                  geckoProfile.meta = {};
+                }
+                geckoProfile.meta.visualMetrics = result[i].visualMetrics;
+                fs.writeFileSync(profileFilename, JSON.stringify(geckoProfile));
+              } catch (e) {
+                log.error(
+                  `Could not write visual metrics to ${profileFilename}`,
+                  e
+                );
+              }
+            }
+
             i++;
           } catch (e) {
             // If one of the Visual Metrics runs fail, just swallow and try the next one


### PR DESCRIPTION
This change embeds visual metrics into gecko profiles captured by
browsertime, so they can be visualized in the Firefox profiler