### PR TITLE
Change case type of properties in visual metrics

### DIFF
--- a/lib/core/engine/collector.js
+++ b/lib/core/engine/collector.js
@@ -174,24 +174,24 @@ class Collector {
         if (this.options.iterations > 1) {
           log.info(
             `VisualMetrics FirstVisualChange: ${
-              data.visualMetrics.FirstVisualChange
+              data.visualMetrics.firstVisualChange
             } SpeedIndex: ${
-              data.visualMetrics.SpeedIndex
+              data.visualMetrics.speedIndex
             } PerceptualSpeedIndex: ${
-              data.visualMetrics.PerceptualSpeedIndex
+              data.visualMetrics.perceptualSpeedIndex
             } ContentfulSpeedIndex: ${
-              data.visualMetrics.ContentfulSpeedIndex
+              data.visualMetrics.contentfulSpeedIndex
             } VisualComplete85: ${
-              data.visualMetrics.VisualComplete85
-            } LastVisualChange: ${data.visualMetrics.LastVisualChange}`
+              data.visualMetrics.visualComplete85
+            } LastVisualChange: ${data.visualMetrics.lastVisualChange}`
           );
         }
         statistics.addDeep({
           visualMetrics: data.visualMetrics
         });
-        data.visualMetrics.VisualProgress = util.jsonifyVisualProgress(data.visualMetrics.VisualProgress);
-        data.visualMetrics.ContentfulSpeedIndexProgress = util.jsonifyVisualProgress(data.visualMetrics.ContentfulSpeedIndexProgress);
-        data.visualMetrics.PerceptualSpeedIndexProgress = util.jsonifyVisualProgress(data.visualMetrics.PerceptualSpeedIndexProgress);
+        data.visualMetrics.visualProgress = util.jsonifyVisualProgress(data.visualMetrics.visualProgress);
+        data.visualMetrics.contentfulSpeedIndexProgress = util.jsonifyVisualProgress(data.visualMetrics.contentfulSpeedIndexProgress);
+        data.visualMetrics.perceptualSpeedIndexProgress = util.jsonifyVisualProgress(data.visualMetrics.perceptualSpeedIndexProgress);
         results.visualMetrics.push(data.visualMetrics);
       }
       // Put all work that involves storing metrics to disk in a

--- a/lib/support/har/index.js
+++ b/lib/support/har/index.js
@@ -157,17 +157,16 @@ module.exports = {
     // in pageTimings so we can easily show them in PerfCascade
     if (visualMetricsData) {
       const DO_NOT_INCLUDE_IN_HAR_TIMINGS = [
-        'VisualReadiness',
-        'SpeedIndex',
-        'PerceptualSpeedIndex',
-        'ContentfulSpeedIndex',
-        'VisualProgress'
+        'visualReadiness',
+        'speedIndex',
+        'perceptualSpeedIndex',
+        'contentfulSpeedIndex',
+        'visualProgress'
       ];
 
       for (let key of Object.keys(visualMetricsData)) {
         if (DO_NOT_INCLUDE_IN_HAR_TIMINGS.indexOf(key) === -1) {
-          harPageTimings['_' + key.charAt(0).toLowerCase() + key.slice(1)] =
-            visualMetricsData[key];
+          harPageTimings['_' + key] = visualMetricsData[key];
           _visualMetrics[key] = visualMetricsData[key];
         } else if (key !== 'VisualProgress') {
           _visualMetrics[key] = visualMetricsData[key];
@@ -175,8 +174,8 @@ module.exports = {
       }
 
       // Make the visual progress structure more JSON
-      _visualMetrics.VisualProgress = util.jsonifyVisualProgress(
-        visualMetricsData.VisualProgress
+      _visualMetrics.visualProgress = util.jsonifyVisualProgress(
+        visualMetricsData.visualProgress
       );
     } else if (timings && timings.firstPaint) {
       // only add first paint if we don't have visual metrics

--- a/lib/support/util.js
+++ b/lib/support/util.js
@@ -74,34 +74,34 @@ module.exports = {
         );
         speedIndex = this.formatMetric(
           'speedIndex',
-          vm ? vm.SpeedIndex : vm,
+          vm ? vm.speedIndex : vm,
           m
         );
         perceptualSpeedIndex = this.formatMetric(
           'perceptualSpeedIndex',
-          vm ? vm.PerceptualSpeedIndex : vm,
+          vm ? vm.perceptualSpeedIndex : vm,
           m
         );
         contentfulSpeedIndex = this.formatMetric(
           'contentfulSpeedIndex',
-          vm ? vm.ContentfulSpeedIndex : vm,
+          vm ? vm.contentfulSpeedIndex : vm,
           m
         );
         startRender = this.formatMetric(
           'firstVisualChange',
-          vm ? vm.FirstVisualChange : vm,
+          vm ? vm.firstVisualChange : vm,
           m,
           true
         );
         lastVisualChange = this.formatMetric(
           'lastVisualChange',
-          vm ? vm.LastVisualChange : vm,
+          vm ? vm.lastVisualChange : vm,
           m,
           true
         );
         visualComplete85 = this.formatMetric(
           'visualComplete85',
-          vm ? vm.VisualComplete85 : vm,
+          vm ? vm.visualComplete85 : vm,
           m,
           true
         );

--- a/lib/video/postprocessing/finetune/getTimingMetrics.js
+++ b/lib/video/postprocessing/finetune/getTimingMetrics.js
@@ -40,16 +40,16 @@ module.exports = function(videoMetrics, timingMetrics, options) {
   if (options.visualMetrics) {
     metricsAndValues.push({
       name: 'FirstVisualChange',
-      value: vm.FirstVisualChange
+      value: vm.firstVisualChange
     });
-    metricsAndValues.push({ name: 'SpeedIndex', value: vm.SpeedIndex });
+    metricsAndValues.push({ name: 'SpeedIndex', value: vm.speedIndex });
     metricsAndValues.push({
       name: 'VisualComplete85',
-      value: vm.VisualComplete85
+      value: vm.visualComplete85
     });
     metricsAndValues.push({
       name: 'LastVisualChange',
-      value: vm.LastVisualChange
+      value: vm.lastVisualChange
     });
   }
   if (timingMetrics) {

--- a/lib/video/postprocessing/finetune/removeOrange.js
+++ b/lib/video/postprocessing/finetune/removeOrange.js
@@ -14,7 +14,7 @@ module.exports = async function(
   const args = ['-nostdin', '-ss', newStart, '-i', inputFile];
   if (options.visualMetrics) {
     // End the video on last visual change + 1 s
-    const end = newStart + visualMetrics.LastVisualChange / 1000 + 1;
+    const end = newStart + visualMetrics.lastVisualChange / 1000 + 1;
     args.push('-to', end);
   }
   args.push('-c', 'copy', outputFile);

--- a/lib/video/postprocessing/visualmetrics/extraMetrics.js
+++ b/lib/video/postprocessing/visualmetrics/extraMetrics.js
@@ -2,51 +2,51 @@
 
 module.exports = function(metrics) {
   const videoMetrics = {};
-  if (!metrics.VisualReadiness) {
-    metrics.VisualReadiness =
-      Number(metrics.LastVisualChange) - Number(metrics.FirstVisualChange);
+  if (!metrics.visualReadiness) {
+    metrics.visualReadiness =
+      Number(metrics.lastVisualChange) - Number(metrics.firstVisualChange);
   }
   // Jack in that Visual Complete 85%, 95% and 99%
-  if (metrics.VisualProgress) {
-    const eachLine = metrics.VisualProgress.split(',');
+  if (metrics.visualProgress) {
+    const eachLine = metrics.visualProgress.split(',');
     for (const timeAndPercentage of eachLine) {
       const [timestamp, percent] = timeAndPercentage.split('=');
       if (
         parseInt(timestamp, 10) >= 85 &&
-        !metrics.VisualComplete85
+        !metrics.visualComplete85
       ) {
-        metrics.VisualComplete85 = parseInt(percent, 10);
+        metrics.visualComplete85 = parseInt(percent, 10);
       }
       if (
         parseInt(timestamp, 10) >= 95 &&
-        !metrics.VisualComplete95
+        !metrics.visualComplete95
       ) {
-        metrics.VisualComplete95 = parseInt(percent, 10);
+        metrics.visualComplete95 = parseInt(percent, 10);
       }
       if (
         parseInt(timestamp, 10) >= 99 &&
-        !metrics.VisualComplete99
+        !metrics.visualComplete99
       ) {
-        metrics.VisualComplete99 = parseInt(percent, 10);
+        metrics.visualComplete99 = parseInt(percent, 10);
       }
 
       // Oh noo the painting on the screen goes backward
       // see https://github.com/sitespeedio/sitespeed.io/issues/2259#issuecomment-456878707
-      if (metrics.VisualComplete85 && parseInt(timestamp, 10) < 85) {
-        metrics.VisualComplete85 = undefined;
-        metrics.VisualComplete95 = undefined;
-        metrics.VisualComplete95 = undefined;
+      if (metrics.visualComplete85 && parseInt(timestamp, 10) < 85) {
+        metrics.visualComplete85 = undefined;
+        metrics.visualComplete95 = undefined;
+        metrics.visualComplete95 = undefined;
       } else if (
-        metrics.VisualComplete95 &&
+        metrics.visualComplete95 &&
         parseInt(timestamp, 10) < 95
       ) {
-        metrics.VisualComplete95 = undefined;
-        metrics.VisualComplete95 = undefined;
+        metrics.visualComplete95 = undefined;
+        metrics.visualComplete95 = undefined;
       } else if (
-        metrics.VisualComplete99 &&
+        metrics.visualComplete99 &&
         parseInt(timestamp, 10) < 99
       ) {
-        metrics.VisualComplete99 = undefined;
+        metrics.visualComplete99 = undefined;
       }
     }
   }

--- a/vendor/visualmetrics.py
+++ b/vendor/visualmetrics.py
@@ -1309,22 +1309,22 @@ def calculate_visual_metrics(histograms_file, start, end, perceptual, contentful
             f.close()
         if len(histograms) > 1:
             metrics = [
-                {'name': 'First Visual Change',
+                {'name': 'first Visual Change',
                     'value': histograms[1]['time']},
-                {'name': 'Last Visual Change',
+                {'name': 'last Visual Change',
                     'value': histograms[-1]['time']},
-                {'name': 'Speed Index',
+                {'name': 'speed Index',
                  'value': calculate_speed_index(progress)}
             ]
             if perceptual:
                 value, value_progress = calculate_perceptual_speed_index(progress, dirs)
                 metrics.extend((
                         {
-                            'name': 'Perceptual Speed Index',
+                            'name': 'perceptual Speed Index',
                             'value': value
                         },
                         {
-                            'name': 'Perceptual Speed Index Progress',
+                            'name': 'perceptual Speed Index Progress',
                             'value': value_progress
                         }))
             if contentful:
@@ -1332,11 +1332,11 @@ def calculate_visual_metrics(histograms_file, start, end, perceptual, contentful
 
                 metrics.extend((
                         {
-                            'name': 'Contentful Speed Index',
+                            'name': 'contentful Speed Index',
                             'value': value
                         },
                         {
-                            'name': 'Contentful Speed Index Progress',
+                            'name': 'contentful Speed Index Progress',
                             'value': value_progress
                         }))
             if hero_elements_file is not None and os.path.isfile(hero_elements_file):
@@ -1372,22 +1372,22 @@ def calculate_visual_metrics(histograms_file, start, end, perceptual, contentful
                 logging.warn('Hero elements file is not valid: ' + str(hero_elements_file))
         else:
             metrics = [
-                {'name': 'First Visual Change',
+                {'name': 'first Visual Change',
                     'value': histograms[0]['time']},
-                {'name': 'Last Visual Change', 'value': histograms[0]['time']},
-                {'name': 'Visually Complete', 'value': histograms[0]['time']},
-                {'name': 'Speed Index', 'value': 0}
+                {'name': 'last Visual Change', 'value': histograms[0]['time']},
+                {'name': 'visually Complete', 'value': histograms[0]['time']},
+                {'name': 'speed Index', 'value': 0}
             ]
             if perceptual:
-                metrics.append({'name': 'Perceptual Speed Index', 'value': 0})
+                metrics.append({'name': 'perceptual Speed Index', 'value': 0})
             if contentful:
-                metrics.append({'name': 'Contentful Speed Index', 'value': 0})
+                metrics.append({'name': 'contentful Speed Index', 'value': 0})
         prog = ''
         for p in progress:
             if len(prog):
                 prog += ", "
             prog += '{0:d}={1:d}'.format(p['time'], int(p['progress']))
-        metrics.append({'name': 'Visual Progress', 'value': prog})
+        metrics.append({'name': 'visual Progress', 'value': prog})
 
     return metrics
 


### PR DESCRIPTION
Current case type of visual metrics properties in browsertime.json is
inconsistent with the rest of the file. This change switches the case
type of these properties from Pascal Case to Camel Case.