### PR TITLE
Fix a bug for analyzing VisualComplete85

### DIFF
--- a/lib/video/postprocessing/visualmetrics/extraMetrics.js
+++ b/lib/video/postprocessing/visualmetrics/extraMetrics.js
@@ -12,39 +12,39 @@ module.exports = function(metrics) {
     for (const timeAndPercentage of eachLine) {
       const [timestamp, percent] = timeAndPercentage.split('=');
       if (
-        parseInt(timestamp, 10) >= 85 &&
+        parseInt(percent, 10) >= 85 &&
         !metrics.VisualComplete85
       ) {
-        metrics.VisualComplete85 = parseInt(percent, 10);
+        metrics.VisualComplete85 = parseInt(timestamp, 10);
       }
       if (
-        parseInt(timestamp, 10) >= 95 &&
+        parseInt(percent, 10) >= 95 &&
         !metrics.VisualComplete95
       ) {
-        metrics.VisualComplete95 = parseInt(percent, 10);
+        metrics.VisualComplete95 = parseInt(timestamp, 10);
       }
       if (
-        parseInt(timestamp, 10) >= 99 &&
+        parseInt(percent, 10) >= 99 &&
         !metrics.VisualComplete99
       ) {
-        metrics.VisualComplete99 = parseInt(percent, 10);
+        metrics.VisualComplete99 = parseInt(timestamp, 10);
       }
 
       // Oh noo the painting on the screen goes backward
       // see https://github.com/sitespeedio/sitespeed.io/issues/2259#issuecomment-456878707
-      if (metrics.VisualComplete85 && parseInt(timestamp, 10) < 85) {
+      if (metrics.VisualComplete85 && parseInt(percent, 10) < 85) {
         metrics.VisualComplete85 = undefined;
         metrics.VisualComplete95 = undefined;
         metrics.VisualComplete95 = undefined;
       } else if (
         metrics.VisualComplete95 &&
-        parseInt(timestamp, 10) < 95
+        parseInt(percent, 10) < 95
       ) {
         metrics.VisualComplete95 = undefined;
         metrics.VisualComplete95 = undefined;
       } else if (
         metrics.VisualComplete99 &&
-        parseInt(timestamp, 10) < 99
+        parseInt(percent, 10) < 99
       ) {
         metrics.VisualComplete99 = undefined;
       }


### PR DESCRIPTION
The refactor I did in 96218b05a545f92a0f1dee86fa22589b90ce94f2 swapped
timestamp and percent, and placed them into a wrong order. This patch
fixes it.