### PR TITLE
Bug 1564256 - Make binary dependencies optional.

### DIFF
--- a/lib/chrome/webdriver/index.js
+++ b/lib/chrome/webdriver/index.js
@@ -5,7 +5,6 @@ const chrome = require('selenium-webdriver/chrome');
 const proxy = require('selenium-webdriver/proxy');
 const pick = require('lodash.pick');
 const isEmpty = require('lodash.isempty');
-const chromedriver = require('@sitespeed.io/chromedriver');
 const log = require('intel').getLogger('browsertime.chrome');
 const get = require('lodash.get');
 const path = require('path');
@@ -26,11 +25,14 @@ module.exports.configureBuilder = function(builder, baseDir, options) {
   const moduleRootPath = path.resolve(__dirname, '..', '..', '..');
 
   if (!hasConfiguredChromeDriverService) {
-    const chromedriverPath = get(
+    let chromedriverPath = get(
       chromeConfig,
-      'chromedriverPath',
-      chromedriver.binPath()
+      'chromedriverPath'
     );
+    if (!chromedriverPath) {
+      const chromedriver = require('@sitespeed.io/chromedriver');
+      chromedriverPath = chromedriver.binPath();
+    }
 
     let serviceBuilder = new chrome.ServiceBuilder(chromedriverPath);
     if (options.verbose >= 2) {

--- a/lib/firefox/webdriver/index.js
+++ b/lib/firefox/webdriver/index.js
@@ -8,18 +8,20 @@ const isEmpty = require('lodash.isempty');
 const log = require('intel').getLogger('browsertime.firefox');
 const util = require('../../support/util');
 const get = require('lodash.get');
-const geckodriver = require('@sitespeed.io/geckodriver');
 const defaultFirefoxPreferences = require('./firefoxPreferences');
 
 module.exports.configureBuilder = function(builder, baseDir, options) {
   const firefoxConfig = options.firefox || {};
   const moduleRootPath = path.resolve(__dirname, '..', '..', '..');
 
-  const geckodriverPath = get(
+  let geckodriverPath = get(
     firefoxConfig,
-    'geckodriverPath',
-    geckodriver.binPath()
+    'geckodriverPath'
   );
+  if (!geckodriverPath) {
+    const geckodriver = require('@sitespeed.io/geckodriver');
+    geckodriverPath = geckodriver.binPath();
+  }
 
   // Other implementations configure the Web Driver service only once.
   // However, `selenium-webdriver` fixes a port for `geckodriver` when

--- a/lib/screenshot/index.js
+++ b/lib/screenshot/index.js
@@ -1,6 +1,12 @@
 'use strict';
 
-const sharp = require('sharp');
+let sharp;
+try {
+  sharp = require('sharp');
+} catch (e) {
+  sharp = null;
+}
+
 const path = require('path');
 const merge = require('lodash.merge');
 const defaultConfig = require('./defaults');
@@ -42,6 +48,9 @@ class ScreenshotManager {
   }
 
   async save(name, data, url) {
+    if (!sharp) {
+      return null;
+    }
     if (this.config.type === 'png') {
       return savePng(
         name,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "@sitespeed.io/throttle": "0.5.1",
     "adbkit": "2.11.0",
-    "@sitespeed.io/chromedriver": "74.0.372-9.6-1",
     "chrome-har": "0.9.1",
     "dayjs": "1.8.13",
     "del": "4.1.0",
@@ -23,13 +22,14 @@
     "lodash.set": "4.3.2",
     "mkdirp": "0.5.1",
     "selenium-webdriver": "https://github.com/mozilla/selenium/archive/v3.6.0-android.tar.gz",
-    "@sitespeed.io/geckodriver": "0.24.0",
     "tracium": "0.2.0",
     "valid-url": "1.0.9",
     "@cypress/xvfb": "1.2.4",
     "yargs": "13.2.2"
   },
   "optionalDependencies": {
+    "@sitespeed.io/chromedriver": "74.0.372-9.6-1",
+    "@sitespeed.io/geckodriver": "0.24.0",
     "sharp": "0.22.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,12 +23,14 @@
     "lodash.set": "4.3.2",
     "mkdirp": "0.5.1",
     "selenium-webdriver": "https://github.com/mozilla/selenium/archive/v3.6.0-android.tar.gz",
-    "sharp": "0.22.1",
     "@sitespeed.io/geckodriver": "0.24.0",
     "tracium": "0.2.0",
     "valid-url": "1.0.9",
     "@cypress/xvfb": "1.2.4",
     "yargs": "13.2.2"
+  },
+  "optionalDependencies": {
+    "sharp": "0.22.1"
   },
   "devDependencies": {
     "bluebird": "3.5.1",


### PR DESCRIPTION
This is part of [Bug 1564256](https://bugzilla.mozilla.org/show_bug.cgi?id=1564256).  That ticket will make `mach browsertime --setup` run in automation.  The result will be used across platforms and therefore should not have binary dependencies in the resulting `node_modules` tree.  Rather than post-process the `node_modules` tree in a non-standard way, we make certain dependencies optional at the NPM level and then run the install with appropriate flags in automation.