### PR TITLE
Android gecko profiling

### DIFF
--- a/lib/core/engine/command/measure.js
+++ b/lib/core/engine/command/measure.js
@@ -148,8 +148,9 @@ class Measure {
         this.browser,
         this.options
       );
-      await this.engineDelegate.onStartIteration(this.browser, this.index);
     }
+    await this.engineDelegate.onStartIteration(this.browser, this.index);
+
     this.result.push(getNewResult());
     this.result[this.numberOfMeasuredPages].timestamp = engineUtils.timestamp();
 

--- a/lib/core/engine/index.js
+++ b/lib/core/engine/index.js
@@ -131,7 +131,7 @@ class Engine {
     const storageManager = new StorageManager(name, options);
     const engineDelegate =
       this.options.browser === 'firefox'
-        ? new FirefoxDelegate(storageManager.directory, this.options)
+        ? new FirefoxDelegate(storageManager, this.options)
         : new ChromeDelegate(storageManager, this.options);
     const iteration = new Iteration(
       storageManager,

--- a/lib/firefox/geckoProfilerDefaults.js
+++ b/lib/firefox/geckoProfilerDefaults.js
@@ -3,6 +3,7 @@
 module.exports = {
   features: 'js,stackwalk,leaf,responsiveness',
   threads: 'GeckoMain,Compositor,Renderer',
-  interval: 1,
+  desktop_sampling_interval: 1,
+  android_sampling_interval: 4,
   bufferSize: 1000000
 };

--- a/lib/firefox/webdriver/firefoxDelegate.js
+++ b/lib/firefox/webdriver/firefoxDelegate.js
@@ -7,12 +7,14 @@ const { promisify } = require('util');
 const rename = promisify(fs.rename);
 const pathToFolder = require('../../support/pathToFolder');
 const path = require('path');
+const { isAndroidConfigured, createAndroidConnection } = require('../../android');
 
 class FirefoxDelegate {
-  constructor(baseDir, options) {
+  constructor(storageManager, options) {
     // Lets keep this and hope that we in the future will have HAR for FF again
     this.skipHar = options.skipHar;
-    this.baseDir = baseDir;
+    this.baseDir = storageManager.directory;
+    this.storageManager = storageManager;
     this.includeResponseBodies = options.firefox
       ? options.firefox.includeResponseBodies
       : 'none';
@@ -53,6 +55,7 @@ class FirefoxDelegate {
         log.error('Unknown Gecko Profiler API');
       }
 
+      log.info('Start GeckoProfiler.');
       await runner.runPrivilegedScript(script, 'Start GeckoProfiler');
     }
   }
@@ -75,24 +78,38 @@ class FirefoxDelegate {
     }
 
     if (this.firefoxConfig.geckoProfiler) {
-      let profileFilename = path.join(
-        this.baseDir,
-        pathToFolder(result.url, this.options),
+      let profileDir = await this.storageManager.createSubDataDir(
+        pathToFolder(result.url, this.options)
+      );
+      let destinationFilename = path.join(
+        profileDir,
         `geckoProfile-${index}.json`
       );
+
+      let deviceProfileFilename = destinationFilename;
+      if (isAndroidConfigured(this.options)) {
+        deviceProfileFilename = `/sdcard/geckoProfile-${index}.json`;
+      }
 
       // Must use String.raw or else the backslashes on Windows will be escapes.
       const script = `
       var callback = arguments[arguments.length - 1];
-       Services.profiler.dumpProfileToFileAsync(String.raw\`${profileFilename}\`)
+       Services.profiler.dumpProfileToFileAsync(String.raw\`${deviceProfileFilename}\`)
         .then(callback)
         .catch((e) => callback({'error' : e}));
        `;
       await runner.runPrivilegedAsyncScript(script, 'Collect GeckoProfiler');
+      log.info('Stop GeckoProfiler.');
       await runner.runPrivilegedScript(
         'Services.profiler.StopProfiler();',
         'Stop GeckoProfiler'
       );
+
+      if (isAndroidConfigured(this.options)) {
+        let android = createAndroidConnection(this.options);
+        await android.initConnection();
+        await android._downloadFile(deviceProfileFilename, destinationFilename);
+      }
     }
 
     if (this.skipHar) {

--- a/lib/firefox/webdriver/firefoxDelegate.js
+++ b/lib/firefox/webdriver/firefoxDelegate.js
@@ -8,6 +8,7 @@ const rename = promisify(fs.rename);
 const pathToFolder = require('../../support/pathToFolder');
 const path = require('path');
 const { isAndroidConfigured, createAndroidConnection } = require('../../android');
+const geckoProfilerDefaults = require('../geckoProfilerDefaults');
 
 class FirefoxDelegate {
   constructor(storageManager, options) {
@@ -37,6 +38,17 @@ class FirefoxDelegate {
       let threadString = '["' + chosenThreads.join('","') + '"]';
 
       let interval = this.firefoxConfig.geckoProfilerParams.interval;
+
+      // Set platform specific sampling intervals if not explicitly specified.
+      if (
+        this.firefoxConfig.geckoProfiler &&
+        !this.firefoxConfig.geckoProfilerParams.interval
+      ) {
+        interval = isAndroidConfigured(this.options)
+          ? geckoProfilerDefaults.android_sampling_interval
+          : geckoProfilerDefaults.desktop_sampling_interval;
+      }
+
       let bufferSize = this.firefoxConfig.geckoProfilerParams.bufferSize;
 
       // Firefox 69 and above has a slightly different API for StartProfiler

--- a/lib/support/browserScript.js
+++ b/lib/support/browserScript.js
@@ -72,7 +72,7 @@ function generateScriptObject(name, path, contents) {
       typeof scriptAndMetadataObject.function === 'function' &&
       typeof scriptAndMetadataObject.requires === 'object'
     ) {
-      log.info(name + ' is a new-style script object.');
+      log.verbose(name + ' is a new-style script object.');
       return {
         name: name,
         requires: scriptAndMetadataObject.requires,

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -282,8 +282,11 @@ module.exports.parseCommandLine = function parseCommandLine() {
       group: 'firefox'
     })
     .option('firefox.geckoProfilerParams.interval', {
-      describe: 'Sampling interval in ms.',
-      default: geckoProfilerDefaults.interval,
+      describe: `Sampling interval in ms.  Defaults to ${
+        geckoProfilerDefaults.desktop_sampling_interval
+      } on desktop, and ${
+        geckoProfilerDefaults.android_sampling_interval
+      } on android.`,
       type: 'number',
       group: 'firefox'
     })


### PR DESCRIPTION
Add Android support for gecko profiling and update the sampling interval based on platform.  Fixes https://github.com/mozilla/browsertime/issues/13.