### PR TITLE
Update preferences to match default settings as much as possible.

### DIFF
--- a/lib/firefox/webdriver/firefoxPreferences.js
+++ b/lib/firefox/webdriver/firefoxPreferences.js
@@ -11,37 +11,9 @@ module.exports = {
   'dom.performance.time_to_first_interactive.enabled': true,
   // Use hidden TTCP
   'dom.performance.time_to_contentful_paint.enabled': true,
-  // IPV6 sometimes makes DNS slow on Linux
-  'network.dns.disableIPv6': true,
   'browser.startup.homepage': 'about:blank',
-  /* Extra tracking protection https://wiki.mozilla.org/Security/Tracking_protection */
-  'privacy.trackingprotection.enabled': false,
-  'privacy.trackingprotection.pbmode.enabled': false,
-  'privacy.trackingprotection.annotate_channels': false,
-  'services.sync.prefs.sync.privacy.trackingprotection.enabled': false,
-  'services.sync.prefs.sync.privacy.trackingprotection.pbmode.enabled': false,
-  'browser.safebrowsing.provider.mozilla.updateURL': '',
-  'browser.safebrowsing.provider.mozilla.gethashURL': '',
-
-  /* Disable heartbeat https://wiki.mozilla.org/Firefox/Shield/Heartbeat */
-  'browser.selfsupport.url': '',
-  'browser.selfsupport.enabled': false,
 
   'devtools.devedition.promo.enabled': false,
-
-  /* Disable detectportal.firefox.com */
-  'network.captive-portal-service.enabled': false,
-  'browser.search.geoip.url': '',
-  /* Disable telemetry  https://wiki.mozilla.org/Telemetry/Testing */
-  'toolkit.telemetry.prompted': 2,
-  'toolkit.telemetry.rejected': true,
-  'toolkit.telemetry.enabled': false,
-  'toolkit.telemetry.reportingpolicy.firstRun': false,
-
-  /* https://support.mozilla.org/en-US/kb/how-stop-firefox-making-automatic-connections */
-  'browser.safebrowsing.downloads.remote.enabled': false,
-  'browser.startup.homepage_override.mstone': 'ignore',
-  'extensions.getAddons.cache.enabled': false,
 
   // Preferences from
   // https://searchfox.org/mozilla-central/source/testing/talos/talos/config.py
@@ -52,9 +24,6 @@ module.exports = {
   'browser.bookmarks.restore_default_bookmarks': false,
   'browser.bookmarks.added_static_root': true,
   'browser.places.importBookmarksHTML': false,
-  'browser.cache.disk.capacity': 1048576,
-  'browser.cache.disk.smart_size.first_run': false,
-  'browser.cache.disk.smart_size_cached_value': 1048576,
   'browser.newtabpage.directory.ping': '',
   'browser.newtabpage.directory.source': 'data:application/json,{}',
   'browser.newtabpage.enabled': false,
@@ -63,12 +32,6 @@ module.exports = {
   'browser.newtab.preload': false,
   'browser.pagethumbnails.capturing_disabled': true,
   'browser.rights.3.shown': true,
-  'browser.safebrowsing.downloads.enabled': false,
-  'browser.safebrowsing.enabled': false,
-  'browser.safebrowsing.phishing.enabled': false,
-  'browser.safebrowsing.malware.enabled': false,
-  'browser.safebrowsing.remotelookups': false,
-  'browser.safebrowsing.provider.mozilla.updateURL ': '',
   'browser.search.update': false,
   'browser.sessionstore.resume_from_crash': false,
   'browser.shell.checkDefaultBrowser': false,
@@ -112,8 +75,9 @@ module.exports = {
   'security.warn_submit_insecure': false,
   'services.sync.migrated': true,
   'services.sync.engine.bookmarks': false,
-  'layers.acceleration.disabled': true,
-  'gfx.direct2d.disabled': true,
+  'toolkit.telemetry.server': 'https://127.0.0.1/telemetry-dummy/',
+  'toolkit.content-background-hang-monitor.disabled': true,
+  'gfx.webrender.force-disabled': true,
   'xpinstall.whitelist.add': '',
   'xpinstall.whitelist.add.36': '',
   'xpinstall.signatures.required': false,

--- a/lib/firefox/webdriver/index.js
+++ b/lib/firefox/webdriver/index.js
@@ -134,6 +134,29 @@ module.exports.configureBuilder = function(builder, baseDir, options) {
     }
   }
 
+  if (firefoxConfig.disableSafeBrowsing) {
+    profile.setPreference('browser.safebrowsing.downloads.enabled', false)
+    profile.setPreference('browser.safebrowsing.enabled', false);
+    profile.setPreference('browser.safebrowsing.phishing.enabled', false);
+    profile.setPreference('browser.safebrowsing.malware.enabled', false);
+    profile.setPreference('browser.safebrowsing.remotelookups', false);
+    profile.setPreference('browser.safebrowsing.provider.mozilla.updateURL', '');
+    profile.setPreference('browser.safebrowsing.provider.google4.dataSharingURL', '');
+    profile.setPreference('browser.safebrowsing.provider.google4.gethashURL', '');
+    profile.setPreference('browser.safebrowsing.provider.google4.lists', '');
+    profile.setPreference('browser.safebrowsing.provider.google4.advisoryURL', '');
+    profile.setPreference('browser.safebrowsing.provider.google.updateURL', '');
+    profile.setPreference('browser.safebrowsing.provider.google.reportURL', '');
+    profile.setPreference('browser.safebrowsing.provider.google.advisoryURL', '');
+    profile.setPreference('browser.safebrowsing.provider.google.gethashURL', '');
+    profile.setPreference('browser.safebrowsing.provider.google.lists', '');
+    profile.setPreference('browser.safebrowsing.provider.google4.reportURL', '');
+    profile.setPreference('browser.safebrowsing.provider.google4.updateURL', '');
+    profile.setPreference('browser.safebrowsing.provider.mozilla.gethashURL', '');
+    profile.setPreference('browser.safebrowsing.provider.google.reportMalwareMistakeURL', '');
+    profile.setPreference('browser.safebrowsing.provider.google.reportPhishMistakeURL', '');
+  }
+
   let ffOptions = new firefox.Options();
 
   let firefoxTypes = [

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -254,6 +254,12 @@ module.exports.parseCommandLine = function parseCommandLine() {
       type: 'boolean',
       group: 'firefox'
     })
+    .option('firefox.disableSafeBrowsing', {
+      describe: 'Disable safebrowsing.',
+      default: false,
+      type: 'boolean',
+      group: 'firefox'
+    })
     .option('firefox.windowRecorder', {
       describe:
         'Use the internal compositor-based Firefox window recorder to emit PNG files for each ' +


### PR DESCRIPTION
The current preferences do not reflect the reality of what is commonly used by our users.  Things like disabling TP and hardware acceleration are not realistic testing environments and do not match our default settings.  This should adjust the prefs list to remove any prefs that may impact performance while keeping some other quality of life prefs enabled.