### PR TITLE
Move waitTime outside of the injected JS in case Date.now() is redefined

### DIFF
--- a/lib/core/defaultPageCompleteCheck.js
+++ b/lib/core/defaultPageCompleteCheck.js
@@ -2,9 +2,9 @@
 
 module.exports = `
 return (function(waitTime) {
-    try { 
+    try {
         var end = window.performance.timing.loadEventEnd;
-        return (end > 0) && (Date.now() > end + waitTime);
+        return end > 0;
     } catch(e) {
         return true;
     }

--- a/lib/core/seleniumRunner.js
+++ b/lib/core/seleniumRunner.js
@@ -163,6 +163,10 @@ class SeleniumRunner {
         pageCompleteCheckTimeout,
         `Running page complete check ${pageCompleteCheck} took too long `
       );
+      log.debug(
+        `Waiting after load event for ${waitTime} ms.`
+      );
+      await delay(waitTime);
     } catch (e) {
       log.error('Failed to wait ' + e);
       throw new UrlLoadError('Failed to wait ', {


### PR DESCRIPTION
When using Chrome+WPR,  the Date.now() and loadEventEnd times do not seem to line up properly leading to timeouts.  Moving the waitTime outside of the injected JS is a safer alternative and loadEventEnd should be 0 until the event is fired.