### PR TITLE
Fix the GeckoProfiler API call and prefs with the latest Firefox API

### DIFF
--- a/lib/firefox/geckoProfilerDefaults.js
+++ b/lib/firefox/geckoProfilerDefaults.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  features: 'js,stackwalk,leaf,responsiveness',
+  features: 'js,stackwalk,leaf',
   threads: 'GeckoMain,Compositor,Renderer',
   desktop_sampling_interval: 1,
   android_sampling_interval: 4,

--- a/lib/firefox/webdriver/firefoxDelegate.js
+++ b/lib/firefox/webdriver/firefoxDelegate.js
@@ -52,6 +52,7 @@ class FirefoxDelegate {
       let bufferSize = this.firefoxConfig.geckoProfilerParams.bufferSize;
 
       // Firefox 69 and above has a slightly different API for StartProfiler
+      // See nsIProfiler::StartProfiler in tools/profiler/gecko/nsIProfiler.idl
       const parameterLength = await runner.runPrivilegedScript(
         'return Services.profiler.StartProfiler.length;',
         'Get StartProfiler.length'
@@ -61,10 +62,11 @@ class FirefoxDelegate {
       if (parameterLength === 7) {
         script = `Services.profiler.StartProfiler(${bufferSize},${interval},${featureString},
         ${chosenFeatures.length},${threadString},${chosenThreads.length});`;
-      } else if (parameterLength === 5) {
+      } else if (parameterLength === 5 || parameterLength === 6) {
         script = `Services.profiler.StartProfiler(${bufferSize},${interval},${featureString},${threadString});`;
       } else {
         log.error('Unknown Gecko Profiler API');
+        throw new Error('Unknown Gecko Profiler API');
       }
 
       log.info('Start GeckoProfiler.');
@@ -104,6 +106,7 @@ class FirefoxDelegate {
       }
 
       // Must use String.raw or else the backslashes on Windows will be escapes.
+      log.info(`Collecting Gecko profile in ${destinationFilename}`);
       const script = `
       var callback = arguments[arguments.length - 1];
        Services.profiler.dumpProfileToFileAsync(String.raw\`${deviceProfileFilename}\`)


### PR DESCRIPTION
The feature was removed in https://bugzilla.mozilla.org/show_bug.cgi?id=1572337