### PR TITLE
Add a temporary workaround for orange frame removal issue in WR

### DIFF
--- a/lib/video/screenRecording/setOrangeBackground.js
+++ b/lib/video/screenRecording/setOrangeBackground.js
@@ -7,6 +7,24 @@ module.exports = async function(driver) {
   // https://github.com/sitespeedio/browsertime/issues/802
   const orangeScript = `
       (function() {
+        // Adding this extra layer of white frame fixes
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=1606365
+        // Not clear why it fixes this bug, looks like when
+        // WebRender is enabled, orange frame isn't being
+        // removed correctly if it's the only element
+        // in the document.
+        const white = document.createElement('div');
+        white.id = 'browsertime-white';
+        white.style.position = 'absolute';
+        white.style.top = '0';
+        white.style.left = '0';
+        white.style.width = Math.max(document.documentElement.clientWidth, document.body.clientWidth) + 'px';
+        white.style.height = Math.max(document.documentElement.clientHeight,document.body.clientHeight) + 'px';
+        white.style.backgroundColor = 'white';
+        white.style.zIndex = '2147483647';
+        document.body.appendChild(white);
+        document.body.style.display = '';
+
         const orange = document.createElement('div');
         orange.id = 'browsertime-orange';
         orange.style.position = 'absolute';


### PR DESCRIPTION
This is the tracking bug
https://bugzilla.mozilla.org/show_bug.cgi?id=1606365