### PR TITLE
Record orange frame duration in browsertime

### DIFF
--- a/lib/video/postprocessing/visualmetrics/extraMetrics.js
+++ b/lib/video/postprocessing/visualmetrics/extraMetrics.js
@@ -52,7 +52,6 @@ module.exports = function(metrics) {
   }
   if (metrics.videoRecordingStart) {
     videoMetrics.videoRecordingStart = metrics.videoRecordingStart;
-    delete metrics.videoRecordingStart;
   }
   videoMetrics.visualMetrics = metrics;
   return videoMetrics;


### PR DESCRIPTION
`videoRecordingStart` is the timestamp of the first frame that's is not orange frame, which indicates how long the orange frame in video. 

Let's record it so that we can measure it. 

cc @acreskeyMoz 