### PR TITLE
Fix a bad syntax in firefox/webdriver/index.js

### DIFF
--- a/lib/firefox/webdriver/index.js
+++ b/lib/firefox/webdriver/index.js
@@ -49,8 +49,8 @@ module.exports.configureBuilder = function(builder, baseDir, options) {
       moduleRootPath,
       'browsersupport',
       'firefox-profile'
-    )),
-    profile = new firefox.Profile(profileTemplatePath);
+    ));
+  const profile = new firefox.Profile(profileTemplatePath);
 
   if (options.userAgent) {
     profile.setPreference('general.useragent.override', options.userAgent);


### PR DESCRIPTION
Maybe it's just my javascript skill, but is the current syntax correct? 